### PR TITLE
Added level 3 emotions

### DIFF
--- a/AoMobileApp/app/EmotionWheel/[secondary]/[tertiary]/[selection].js
+++ b/AoMobileApp/app/EmotionWheel/[secondary]/[tertiary]/[selection].js
@@ -1,8 +1,8 @@
 import { Text } from 'react-native';
 import { Link, useLocalSearchParams } from 'expo-router';
 
-import styles from '../../styles/page';
-import PageWrapper from '../../components/Wrappers/SubPage';
+import styles from '../../../styles/page';
+import PageWrapper from '../../../components/Wrappers/SubPage';
 
 export default function EmotionWheelSelection() {
   const { selection } = useLocalSearchParams();

--- a/AoMobileApp/app/EmotionWheel/[secondary]/[tertiary]/index.js
+++ b/AoMobileApp/app/EmotionWheel/[secondary]/[tertiary]/index.js
@@ -1,0 +1,21 @@
+import { Text } from "react-native";
+import { useLocalSearchParams  } from 'expo-router'
+
+import emotions from "../../../constants/emotions";
+import Emotions from "../../../components/Emotions";
+import PageWrapper from '../../../components/Wrappers/SubPage';
+
+
+import styles from '../../../styles/page';
+
+export default function EmotionWheelLevel3() {
+  const { tertiary } = useLocalSearchParams();
+  const full_emotion = tertiary ? emotions.find(el => el.secondary.find(innerEl => innerEl.text === tertiary) ) : {};
+  const emotion = full_emotion.secondary.find(el => el.text === tertiary)
+  return(
+    <PageWrapper>
+      <Text style={styles.subtitle}>Select a more specific emotion</Text>
+      <Emotions emotions={emotion?.tertiary || []} baseHref={`/EmotionWheel/${emotion.from}/${emotion.text}/`} />
+    </PageWrapper>
+  );
+};

--- a/AoMobileApp/app/EmotionWheel/[secondary]/index.js
+++ b/AoMobileApp/app/EmotionWheel/[secondary]/index.js
@@ -8,7 +8,7 @@ import PageWrapper from '../../components/Wrappers/SubPage';
 
 import styles from '../../styles/page';
 
-export default function EmotionWheelInner() {
+export default function EmotionWheelLevel2() {
   const { secondary } = useLocalSearchParams();
   const emotion = secondary ? emotions.find(el => el.text === secondary) : {};
   return(

--- a/AoMobileApp/app/EmotionWheel/_layout.js
+++ b/AoMobileApp/app/EmotionWheel/_layout.js
@@ -29,9 +29,15 @@ export default function TabLayout() {
         })}
       />
       <Stack.Screen
-        name="[secondary]/[selection]"
+        name="[secondary]/[tertiary]/index"
         options={({ route }) => ({
-          title: `${route.params.secondary} / ${route.params.selection}`
+          title: `${route.params.secondary} - Level 3`
+        })}
+      />
+      <Stack.Screen
+        name="[secondary]/[tertiary]/[selection]"
+        options={({ route }) => ({
+          title: `${route.params.secondary} / ${route.params.tertiary} / ${route.params.selection}`
         })}
       />
     </Stack>

--- a/AoMobileApp/app/constants/emotions.js
+++ b/AoMobileApp/app/constants/emotions.js
@@ -3,16 +3,64 @@ export default [{
   emoji: '0x1F631',
   secondary: [{
     text: 'Amazed',
-    emoji: '0x1F632'
+    emoji: '0x1F632',
+    tertiary: [
+      {
+        text: 'Astonished',
+        emoji: '0x1F632',
+        from: 'Amazed'
+      },
+      {
+        text: 'Awe',
+        emoji: '0x1F929',
+        from: 'Amazed'
+      }
+    ]
   }, {
     text: 'Confused',
-    emoji: '0x1F615'
+    emoji: '0x1F615',
+    tertiary: [
+      {
+        text: 'Disillusioned',
+        emoji: '0x1FA84',
+        from: 'Confused'
+      },
+      {
+        text: 'Perplexed',
+        emoji: '0x1F914',
+        from: 'Confused'
+      }
+    ]
   }, {
     text: 'Excited',
-    emoji: '0x1F606'
+    emoji: '0x1F606',
+    tertiary: [
+      {
+        text: 'Eager',
+        emoji: '0x1F92D',
+        from: 'Excited'
+      },
+      {
+        text: 'Energetic',
+        emoji: '0x1FAE8',
+        from: 'Excited'
+      }
+    ]
   }, {
     text: 'Startled',
-    emoji: '0x1F633'
+    emoji: '0x1F633',
+    tertiary: [
+      {
+        text: 'Dismayed',
+        emoji: '0x1F616',
+        from: 'Startled'
+      },
+      {
+        text: 'Shocked',
+        emoji: '0x1F632',
+        from: 'Startled'
+      }
+    ]
   }]
 }, {
   text: 'Happy',


### PR DESCRIPTION
Level 3 emotions are added for the 'Surprised' base emotion. Want to get verification from AO before filling out the others.

TODO:
- Add level 3 emotions for the other base emotions
- Fix the url being /emotion_wheel/undefined/[level_3_emotion] when selecting a level 3 emotion. 
     -  This does not cause errors right now but should be resolved before we hand over to AO.